### PR TITLE
We should be able to pass additional options to compressor.

### DIFF
--- a/lib/AmdCompiler.js
+++ b/lib/AmdCompiler.js
@@ -346,7 +346,11 @@ function compileMinified(modules, options) {
 
 		// Compress and mangle
 		if (options.compress) {
-			compressor = UglifyJS.Compressor({unused: false}); // TODO: Fix this
+			if (typeof options.compress !== 'object') {
+				options.compress = {unused: false};
+			}
+
+			compressor = UglifyJS.Compressor(options.compress); // TODO: Fix this
 			toplevel = toplevel.transform(compressor);
 			toplevel.figure_out_scope();
 			toplevel.compute_char_frequency();


### PR DESCRIPTION
Suppose we need to pass some global variables to UglifyJS for debugging purposes.
