### PR TITLE
Fix moduleOverrides to work properly.

### DIFF
--- a/lib/AmdCompiler.js
+++ b/lib/AmdCompiler.js
@@ -212,7 +212,7 @@ function parseModules(options) {
 						var depFilePath = resolveId(id);
 
 						if (options.moduleOverrides && options.moduleOverrides[id]) {
-							filePath = options.moduleOverrides[id];
+							depFilePath = options.moduleOverrides[id];
 						}
 
 						if (!loadedPaths[depFilePath] && shouldLoadModule(id)) {


### PR DESCRIPTION
When a module override was present, it was being assigned to filePath,
rather than depFilePath, so the override was not actually being used.

This fix was necessary for the jQuery builds of TinyMCE to work properly.
