### PR TITLE
Initialize default reporter right away.

### DIFF
--- a/lib/AmdCompiler.js
+++ b/lib/AmdCompiler.js
@@ -6,7 +6,7 @@ var crypto = require('crypto');
 var utils = require("./Utils");
 var reporter = require("./reporter");
 
-var currentReporter;
+var currentReporter = reporter.create();
 
 function log(reporter, level, message) {
 	if (reporter && reporter[level]) {


### PR DESCRIPTION
To avoid undefined error, when individual methods are invoked separately.

Related: https://github.com/moxiecode/moxie/issues/120.